### PR TITLE
Fix typos in flag specification when running GenomeWarpSerial.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ to transform from hg19 to hg38 is
 ## Building this project
 
 1. git clone this repository.
-1. Use a recent version of [Apache Maven](http://maven.apache.org/download.cgi) 
+1. Use a recent version of [Apache Maven](http://maven.apache.org/download.cgi)
 (e.g., version 3.3.3) to build this code:
 
 ```
@@ -111,14 +111,14 @@ The program is executed as follows:
 
 ```bash
 java -jar target/verilylifesciences-genomewarp-1.0.0-runnable.jar \
-  --lift_over_chain_path="${chain}" \
-  --raw_query_vcf="${queryvcf}" \
-  --raw_query_bed="${querybed}" \
-  --ref_query_fasta="${queryfasta}" \
-  --ref_target_fasta="${targetfasta}" \
-  --work_dir="${workdir}" \
-  --output_variants_file="${targetvcf}" \
-  --output_regions_file="${targetbed}"
+  --lift_over_chain_path "${chain}" \
+  --raw_query_vcf "${queryvcf}" \
+  --raw_query_bed "${querybed}" \
+  --ref_query_fasta "${queryfasta}" \
+  --ref_target_fasta "${targetfasta}" \
+  --work_dir "${workdir}" \
+  --output_variants_file "${targetvcf}" \
+  --output_regions_file "${targetbed}"
 ```
 
 When run, logging statements provide progress indications. GenomeWarp should


### PR DESCRIPTION
The flags were specified as --flag=value, but should be --flag value (i.e. no "=").
