### PR TITLE
Add support for chromosome-specific transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ When run, logging statements provide progress indications. GenomeWarp should
 convert a single-sample VCF containing millions of variants genome-wide in under
 30 minutes.
 
+Run the program with no arguments to see the usage message and additional flags.
+
 ## Notes
 There are multiple reasons why a confidently-called region in the query assembly
 (and any variants therein) may not appear in the target assembly. GenomeWarp is

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ it generates two output files:
 The program is executed as follows:
 
 ```bash
-java -jar target/verilylifesciences-genomewarp-1.1.0-runnable.jar \
+java -jar target/verilylifesciences-genomewarp-1.2.0-runnable.jar \
   --lift_over_chain_path "${chain}" \
   --raw_query_vcf "${queryvcf}" \
   --raw_query_bed "${querybed}" \

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <groupId>com.verily.genomewarp</groupId>
   <artifactId>verilylifesciences-genomewarp</artifactId>
   <name>Verily Life Sciences GenomeWarp</name>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <description>GenomeWarp and associated utility libraries. Utility libraries
     include VcfToVariant and VariantToVcf, which are used to convert between
     VCF-formatted files and Variant V1 protos.</description>

--- a/src/main/java/com/verily/genomewarp/GenomeWarpSerial.java
+++ b/src/main/java/com/verily/genomewarp/GenomeWarpSerial.java
@@ -114,6 +114,13 @@ public final class GenomeWarpSerial {
     public String workDir = null;
 
     @Parameter(
+      description = "Query chromosomes to warp. A comma-separated list of chromosomes, e.g. 'chr1,chr2'. "
+      + "If unspecified, all regions and variants are attempted.",
+      names = "--query_chroms_to_warp"
+    )
+    public String queryChromsToWarp = null;
+
+    @Parameter(
       description = "Keep homozygous reference calls",
       names = "--keep_homozygous_reference_calls"
     )
@@ -206,6 +213,33 @@ public final class GenomeWarpSerial {
     return headerStrings;
   }
 
+  /**
+   * Returns a set of all query chromosomes to attempt to warp.
+   *
+   * @param toWarp a comma-separated string of query chromosomes to warp, or null if all should be warped
+   * @return a Set of chromosomes to warp, or null if all should be warped
+   */
+  private static Set<String> parseQueryChromsToWarp(String toWarp) {
+    if (toWarp == null) return null;
+
+    Set<String> retval = new HashSet<>();
+    for (String token : toWarp.split(",")) {
+      retval.add(token.trim());
+    }
+    return retval;
+  }
+
+  /**
+   * Returns true if and only if the chromosome should be warped.
+   * 
+   * @param chromosomesToWarp a set of chromosomes to warp, or null if all should be warped
+   * @param chrom the chromosome of interest
+   * @return true if chrom should be warped
+   */
+  public static boolean shouldWarpChromosome(Set<String> chromosomesToWarp, String chrom) {
+    if (chromosomesToWarp == null) return true;
+    return chromosomesToWarp.contains(chrom);
+  }
 
   public static RegionType getRegionType(HomologousRange range, Fasta queryFasta,
       Fasta targetFasta) {
@@ -450,7 +484,7 @@ public final class GenomeWarpSerial {
    */
   private static List<HomologousRange> processAndSaveBed(String inputBed, String inputVcf,
       Fasta queryFasta,
-      Fasta targetFasta) {
+      Fasta targetFasta, Set<String> queryChromosomesToRetain) {
     // Open necessary readers
     BufferedReader bedReader = null;
     boolean simplifiedPreprocessing = ARGS.simplifiedRegionsPreprocessing;
@@ -466,7 +500,7 @@ public final class GenomeWarpSerial {
     logger.log(Level.INFO, "Split DNA at non-DNA characters");
     SortedMap<String, List<GenomeRange>> dnaOnlyInputBEDPerChromosome = null;
     try {
-      if ((dnaOnlyInputBEDPerChromosome = GenomeRangeUtils.splitAtNonDNA(queryFasta, bedReader)) == null) {
+      if ((dnaOnlyInputBEDPerChromosome = GenomeRangeUtils.splitAtNonDNA(queryFasta, bedReader, queryChromosomesToRetain)) == null) {
         GenomeWarpUtils.fail(logger, "failed to generate reference genome");
       }
     } catch (IOException ex) {
@@ -574,6 +608,8 @@ public final class GenomeWarpSerial {
       queryVcfToProcess = ARGS.rawQueryVcf;
       queryBedToProcess = ARGS.rawQueryBed;
     }      
+
+    final Set<String> queryChromsToWarp = parseQueryChromsToWarp(ARGS.queryChromsToWarp);
  
     logger.log(Level.INFO, "Creating FASTA structure and jump table");
     try {
@@ -585,7 +621,7 @@ public final class GenomeWarpSerial {
     }
 
     if (!ARGS.onlyGenomeWarp) {
-      namedRegions = processAndSaveBed(queryBedToProcess, queryVcfToProcess, queryFasta, targetFasta);
+      namedRegions = processAndSaveBed(queryBedToProcess, queryVcfToProcess, queryFasta, targetFasta, queryChromsToWarp);
     } else {
       logger.log(Level.INFO, "Region data from files");
       BufferedReader regionsFile = null;
@@ -598,7 +634,10 @@ public final class GenomeWarpSerial {
         String line;
         namedRegions = new ArrayList<>();
         while ((line = regionsFile.readLine()) != null) {
-          namedRegions.add(GenomeWarpUtils.homologousFromString(line));
+          HomologousRange currRegion = GenomeWarpUtils.homologousFromString(line);
+          if (shouldWarpChromosome(queryChromsToWarp, currRegion.getQueryRange().getReferenceName())) {
+            namedRegions.add(currRegion);
+          }
         }
 
         regionsFile.close();

--- a/src/main/java/com/verily/genomewarp/GenomeWarpSerial.java
+++ b/src/main/java/com/verily/genomewarp/GenomeWarpSerial.java
@@ -193,7 +193,7 @@ public final class GenomeWarpSerial {
 
   private static final VCFHeaderVersion DEFAULT_VCF_VERSION = VCFHeaderVersion.VCF4_2;
 
-  private static final String GENOME_WARP_VERSION = "GenomeWarp_v1.1.0";
+  private static final String GENOME_WARP_VERSION = "GenomeWarp_v1.2.0";
 
   private static final String VCF_PART_NAME = "/vcfChunk.vcf.part";
 

--- a/src/main/java/com/verily/genomewarp/utils/GenomeWarpUtils.java
+++ b/src/main/java/com/verily/genomewarp/utils/GenomeWarpUtils.java
@@ -237,7 +237,7 @@ public class GenomeWarpUtils {
    * Given a BufferedReader encoding a file of variants, asssociate the string
    * representation of the variants with a region. This association is done by
    * mapping each region to all variants which share the same reference name
-   * (chromosome) and who's start coordiante is within the region.
+   * (chromosome) and whose start coordinate is within the region.
    *
    * @param regions the list of regions to use as the map's keys
    * @param vcfFile a BufferedReader encoding the input variants

--- a/src/test/java/com/verily/genomewarp/GenomeWarpSerialTest.java
+++ b/src/test/java/com/verily/genomewarp/GenomeWarpSerialTest.java
@@ -143,7 +143,7 @@ public final class GenomeWarpSerialTest {
 
       // Get test result
       SortedMap<String, List<GenomeRange>> got =
-          GenomeRangeUtils.splitAtNonDNA(testFasta, testBED);
+          GenomeRangeUtils.splitAtNonDNA(testFasta, testBED, null);
 
       assertEquals(got.size(), want.size());
       for(String key: got.keySet()) {
@@ -169,7 +169,7 @@ public final class GenomeWarpSerialTest {
         }});
       }};
 
-      SortedMap<String, List<GenomeRange>> got = GenomeRangeUtils.generateBEDFromVCF(testVcf);
+      SortedMap<String, List<GenomeRange>> got = GenomeRangeUtils.generateBEDFromVCF(testVcf, null);
       assertEquals(got.size(), want.size());
       for(String key: got.keySet()) {
         assertTrue(GenomeWarpTestUtils.equivalentRanges(got.get(key), want.get(key)));


### PR DESCRIPTION
This pull request enables a user to run multiple instances of GenomeWarp on a single set of inputs, each time specifying different query chromosomes to process. This may be useful on machines with limited memory resources that cannot transform all regions and variants at once.