### PR TITLE
Verify that input BED contains non-overlapping regions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ it generates two output files:
 The program is executed as follows:
 
 ```bash
-java -jar target/verilylifesciences-genomewarp-1.2.0-runnable.jar \
+java -jar target/verilylifesciences-genomewarp-1.2.1-runnable.jar \
   --lift_over_chain_path "${chain}" \
   --raw_query_vcf "${queryvcf}" \
   --raw_query_bed "${querybed}" \

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <groupId>com.verily.genomewarp</groupId>
   <artifactId>verilylifesciences-genomewarp</artifactId>
   <name>Verily Life Sciences GenomeWarp</name>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
   <description>GenomeWarp and associated utility libraries. Utility libraries
     include VcfToVariant and VariantToVcf, which are used to convert between
     VCF-formatted files and Variant V1 protos.</description>

--- a/src/main/java/com/verily/genomewarp/GenomeWarpSerial.java
+++ b/src/main/java/com/verily/genomewarp/GenomeWarpSerial.java
@@ -510,7 +510,7 @@ public final class GenomeWarpSerial {
     } catch (IOException ex) {
       GenomeWarpUtils.fail(logger, "Failed to read from input bed: " + ex.getMessage());
     } catch (IllegalArgumentException iae) {
-      GenomeWarpUtils.fail(logger, "input bed error: " + iae.getMessage());
+      GenomeWarpUtils.fail(logger, "Input bed error: " + iae.getMessage());
     }
 
     if (allowOverlappingBed) {

--- a/src/main/java/com/verily/genomewarp/GenomeWarpSerial.java
+++ b/src/main/java/com/verily/genomewarp/GenomeWarpSerial.java
@@ -531,7 +531,7 @@ public final class GenomeWarpSerial {
     try {
       dnaOnlyInputBEDPerChromosome = GenomeRangeUtils.splitAtNonDNA(rawInputBed, queryFasta);
     } catch (IOException ex) {
-      GenomeWarpUtils.fail(logger, "failed to read from input FASTA: " + ex.getMessage());
+      GenomeWarpUtils.fail(logger, "Failed to read from input FASTA: " + ex.getMessage());
     }
 
     /**

--- a/src/main/java/com/verily/genomewarp/GenomeWarpSerial.java
+++ b/src/main/java/com/verily/genomewarp/GenomeWarpSerial.java
@@ -508,7 +508,7 @@ public final class GenomeWarpSerial {
     try {
       rawInputBed = GenomeRangeUtils.getBedRanges(bedReader, queryChromosomesToRetain);
     } catch (IOException ex) {
-      GenomeWarpUtils.fail(logger, "failed to read from input bed: " + ex.getMessage());
+      GenomeWarpUtils.fail(logger, "Failed to read from input bed: " + ex.getMessage());
     } catch (IllegalArgumentException iae) {
       GenomeWarpUtils.fail(logger, "input bed error: " + iae.getMessage());
     }

--- a/src/main/java/com/verily/genomewarp/utils/GenomeRangeUtils.java
+++ b/src/main/java/com/verily/genomewarp/utils/GenomeRangeUtils.java
@@ -36,7 +36,7 @@ public class GenomeRangeUtils {
    * @param queryChroms the set of query chromosomes to include
    * @return a hashmap of chromosome to List of GenomeRanges on the requested chromosomes.
    * @throws IllegalArgumentException if the BED does not have all ranges from a single chromosome
-   *   together.
+   *   in a contiguous block in the file.
    */
   public static SortedMap<String, List<GenomeRange>> getBedRanges(BufferedReader bed, Set<String> queryChroms) throws IllegalArgumentException, IOException {
     String line;

--- a/src/main/java/com/verily/genomewarp/utils/GenomeWarpTestUtils.java
+++ b/src/main/java/com/verily/genomewarp/utils/GenomeWarpTestUtils.java
@@ -154,6 +154,22 @@ public class GenomeWarpTestUtils {
     return true;
   }
 
+  public static boolean equivalentGenomeRanges(Map<String, List<GenomeRange>> first,
+      Map<String, List<GenomeRange>> second) {
+    if (first.size() != second.size()) {
+      return false;
+    }
+    for (String key : first.keySet()) {
+      if (!second.containsKey(key)) {
+        return false;
+      }
+      if (!equivalentRanges(first.get(key), second.get(key))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /*
    * Build truth variants
    *

--- a/src/main/java/com/verily/genomewarp/utils/GenomeWarpTestUtils.java
+++ b/src/main/java/com/verily/genomewarp/utils/GenomeWarpTestUtils.java
@@ -137,6 +137,16 @@ public class GenomeWarpTestUtils {
     return true;
   }
 
+  /**
+   * Returns true if and only if the items in each list are identical.
+   *
+   * This function does not require the ordering of the ranges to be the same,
+   * but does require the counts of each item to be the same.
+   *
+   * @param listOne a list of GenomeRanges to compare.
+   * @param listTwo another list of GenomeRanges to compare.
+   * @returns true iff the lists contain the same elements.
+   */
   public static boolean equivalentRanges(List<GenomeRange> listOne,
       List<GenomeRange> listTwo) {
     if (listOne.size() != listTwo.size()) {
@@ -154,6 +164,17 @@ public class GenomeWarpTestUtils {
     return true;
   }
 
+  /**
+   * Returns true if and only if the items in each Map are identical.
+   *
+   * This requires the same chromosomes to be present in each Map, and the per-chromosome
+   * ranges to contain the same items. It does not require the ordering of the ranges to be
+   * the same within chromosomes.
+   *
+   * @param first a Map from chromosome -> GenomeRange list to compare.
+   * @param second another Map from chromosome -> GenomeRange list to compare.
+   * @returns true iff the maps contain the same elements.
+   */
   public static boolean equivalentGenomeRanges(Map<String, List<GenomeRange>> first,
       Map<String, List<GenomeRange>> second) {
     if (first.size() != second.size()) {


### PR DESCRIPTION
This addresses issue #6 , by default failing loudly if the BED has overlapping regions and also supporting the transformation of those BEDs to non-overlapping by passing the --allow_overlapping_bed flag.